### PR TITLE
Change Federation to only use POST

### DIFF
--- a/candig_federation/__main__.py
+++ b/candig_federation/__main__.py
@@ -51,7 +51,6 @@ def main(args=None):
 
     # Self and Local don't actually need to be mapped anymore with the new broadcast logic
     APP.app.config["self"] = "http://{}:{}".format(args.host, args.port)
-    # APP.app.config["local"] = args.localnode
 
     # Service Parse
     APP.app.config["services"] = network.parse_configs("services", args.services,
@@ -69,8 +68,6 @@ def configure_app():
     """
     app = connexion.FlaskApp(__name__, server='tornado', options={"swagger_url": "/"})
 
-    # api_def = pkg_resources.resource_filename('candig_federation', 'api/federation.yaml')
-
     api_def = './api/federation.yaml'
 
     app.add_api(api_def, strict_validation=True, validate_responses=True)
@@ -87,5 +84,7 @@ APPLICATION, PORT = main()
 application = APPLICATION.app
 
 if __name__ == '__main__':
+
+
     APPLICATION.app.logger.info("federation_service running at {}".format(APPLICATION.app.config["self"]))
     APPLICATION.run(port=PORT)

--- a/candig_federation/api/federation.yaml
+++ b/candig_federation/api/federation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: Microservice implementation of CanDIG v1 federation
-  version: "1.0.0-oas3"
+  version: "0.1.0-oas3"
   title: CanDIG Federation API POC
   contact:
     email: dnaidoo@bcgsc.ca

--- a/candig_federation/api/federation_old.yaml
+++ b/candig_federation/api/federation_old.yaml
@@ -82,7 +82,7 @@ parameters:
     description: Path to microservice endpoint
     in: query
     type: string
-    x-example: /variantget/projects
+    x-example: variantget/projects
     required: true
 
   endpoint_payload:
@@ -109,7 +109,7 @@ definitions:
     properties:
       endpoint_path:
         type: string
-        example: /v2/get
+        example: v2/get
       endpoint_payload:
         type: object
 

--- a/candig_federation/api/federation_old_3.yaml
+++ b/candig_federation/api/federation_old_3.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: Microservice implementation of CanDIG v1 federation
-  version: "1.0.0-oas3"
+  version: "0.1.0-oas3"
   title: CanDIG Federation API POC
   contact:
     email: dnaidoo@bcgsc.ca
@@ -10,33 +10,33 @@ info:
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
   /search:
-    # get:
-    #   summary: send query to a microservice
-    #   description: >
-    #     Entry point for Tyk to pass GET requests to CanDIG microservices.
-    #     Federation broadcasting defined by 'federation' header.
-    #   operationId: candig_federation.api.operations.get_search
-    #   parameters:
-    #     - $ref: '#/components/parameters/endpoint_path'
-    #     - $ref: '#/components/parameters/endpoint_payload'
-    #     - $ref: '#/components/parameters/Federation'
-    #   responses:
-    #     '200':
-    #       description: Successful query
-    #     '400':
-    #       description: Bad input parameter
-    #     '403':
-    #       description: Authorization Error
-    #     '404':
-    #       description: Expression not found
-    #     '500':
-    #       description: Internal Error
-    #     '508':
-    #       description: Federation node time out
-    post:
-      summary: Send a request to the CanDIG network
+    get:
+      summary: send query to a microservice
       description: >
-        Entry point for Tyk to pass ALL requests to CanDIG microservices.
+        Entry point for Tyk to pass GET requests to CanDIG microservices.
+        Federation broadcasting defined by 'federation' header.
+      operationId: candig_federation.api.operations.get_search
+      parameters:
+        - $ref: '#/components/parameters/endpoint_path'
+        - $ref: '#/components/parameters/endpoint_payload'
+        - $ref: '#/components/parameters/Federation'
+      responses:
+        '200':
+          description: Successful query
+        '400':
+          description: Bad input parameter
+        '403':
+          description: Authorization Error
+        '404':
+          description: Expression not found
+        '500':
+          description: Internal Error
+        '508':
+          description: Federation node time out
+    post:
+      summary: Add entry to microservice
+      description: >
+        Entry point for Tyk to pass POST requests to CanDIG microservices.
         Federation broadcasting defined by 'federation' header.
       operationId: candig_federation.api.operations.post_search
       parameters:
@@ -70,7 +70,7 @@ components:
       description: Path to microservice endpoint
       in: query
       required: true
-      example: datasets/search
+      example: /variantget/projects
       schema:
         type: string
     endpoint_payload:
@@ -78,12 +78,9 @@ components:
       description: Semicolon separated parameters to pass on
       in: query
       required: false
-      example:
-      explode: true
+      example: 'abc:123;def:789'
       schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/Parameter'
+        type: string
     Federation:
       name: Federation
       description: Flag for federated query. Federation assumed unless false is specified
@@ -94,32 +91,14 @@ components:
     PostObject:
       type: object
       required:
-        - request_type
         - endpoint_path
         - endpoint_payload
       properties:
-        request_type:
-          type: string
-          pattern: '(^GET$)|(^POST$)'
         endpoint_path:
           type: string
           example: v2/get
         endpoint_payload:
           type: object
-    Parameter:
-      type: object
-      properties:
-        key:
-          type: string
-        value:
-          anyOf:
-           - type: string
-           - type: array
-             items:
-              type:
-                string
-      example: '"ontologies": ["DUO:0000001", "DUO:0000028"]'
-
     Error:
       type: object
       required:

--- a/candig_federation/api/models.py
+++ b/candig_federation/api/models.py
@@ -5,7 +5,7 @@ From Swagger file, with python classes via Bravado
 
 import pkg_resources
 import yaml
-from bravado_core.spec import Spec
+from openapi_core import create_spec
 
 # Read in the API definition, and parse it with Bravado
 
@@ -21,10 +21,15 @@ _BRAVADO_CONFIG = {
     'validate_swagger_spec': True
 }
 
-_SWAGGER_SPEC = Spec.from_dict(_SPEC_DICT, config=_BRAVADO_CONFIG)
+_SWAGGER_SPEC = create_spec(_SPEC_DICT, spec_url='federation.yaml')
+
+
+# _SWAGGER_SPEC = Spec.from_dict(_SPEC_DICT, config=_BRAVADO_CONFIG)
 
 # Generate the Python models from the spec
 
-BASEPATH = _SWAGGER_SPEC.flattened_spec['basePath']
-PostObject = _SWAGGER_SPEC.definitions['PostObject']
-Error = _SWAGGER_SPEC.definitions['Error']
+# BASEPATH = _SWAGGER_SPEC.flattened_spec['basePath']
+# PostObject = _SWAGGER_SPEC.definitions['PostObject']
+# Error = _SWAGGER_SPEC.definitions['Error']
+
+BASEPATH = _SWAGGER_SPEC.servers[0].url

--- a/candig_federation/api/operations.py
+++ b/candig_federation/api/operations.py
@@ -9,38 +9,42 @@ from candig_federation.api.federation import FederationResponse
 
 APP = flask.current_app
 
-
-@apilog
-def get_search(endpoint_path, endpoint_payload=None):
-    """Send a GET request to CanDIG services and possibly federate it. Method defined by federation.yaml OpenAPI document.
-
-    :param endpoint_path: Full path of API endpoint such as ``datasets/search``
-    :type endpoint_path: str
-    :param endpoint_payload: Query parameters as key=value strings: ``{ "param1=value1", "param2=value2" }``
-    :type endpoint_payload: object
-    :return: response_object
-
-
-    {
-    "status": Status,
-    "results": [Response],
-    "service": ServiceName
-    }
-
-    Status - Aggregate HTTP response code
-    Response - List of service specific responses
-    ServiceName - Name of service (used for logstash tagging)
-    """
-    service = endpoint_path.split("/")[0]
-    microservice = APP.config['services'][service]
-    federation_response = FederationResponse(url=microservice,
-                                             request='GET',
-                                             endpoint_path=endpoint_path,
-                                             endpoint_payload=endpoint_payload,
-                                             request_dict=flask.request,
-                                             service=service)
-
-    return federation_response.get_response_object()
+#
+# @apilog
+# def get_search(endpoint_path, endpoint_payload=None):
+#     """Send a GET request to CanDIG services and possibly federate it. Method defined by federation.yaml OpenAPI document.
+#
+#     :param endpoint_path: Full path of API endpoint such as ``datasets/search``
+#     :type endpoint_path: str
+#     :param endpoint_payload: Query parameters as key=value strings: ``{ "param1=value1", "param2=value2" }``
+#     :type endpoint_payload: object
+#     :return: response_object
+#
+#
+#     {
+#     "status": Status,
+#     "results": [Response],
+#     "service": ServiceName
+#     }
+#
+#     Status - Aggregate HTTP response code
+#     Response - List of service specific responses
+#     ServiceName - Name of service (used for logstash tagging)
+#     """
+#
+#     print(endpoint_path)
+#     print(endpoint_payload)
+#     print("\n\n\n")
+#     service = endpoint_path.split("/")[0]
+#     microservice = APP.config['services'][service]
+#     federation_response = FederationResponse(url=microservice,
+#                                              request='GET',
+#                                              endpoint_path=endpoint_path,
+#                                              endpoint_payload=endpoint_payload,
+#                                              request_dict=flask.request,
+#                                              service=service)
+#
+#     return federation_response.get_response_object()
 
 
 
@@ -75,12 +79,13 @@ def post_search():
 
     """
     data = json.loads(flask.request.data)
+    request_type = data["request_type"]
     endpoint_path = data["endpoint_path"]
     endpoint_payload = data["endpoint_payload"]
     service = endpoint_path.split("/")[0]
     microservice = APP.config['services'][service]
     federation_response = FederationResponse(url=microservice,
-                                             request='POST',
+                                             request=request_type,
                                              endpoint_path=endpoint_path,
                                              endpoint_payload=endpoint_payload,
                                              request_dict=flask.request,

--- a/docs/source/candig_federation.api.rst
+++ b/docs/source/candig_federation.api.rst
@@ -1,6 +1,8 @@
-candig\_federation.api package
+API package
 ==============================
-
+The main modules within the API package are the ``Operations`` and ``Federation`` modules, which
+implement all the API routes, routing and federation logic. The ``Operations`` module directly implements
+the paths specified in ``federation.yaml`` OpenAPI 3 spec.
 
 Operations Module
 -----------------
@@ -27,3 +29,8 @@ Logging Module
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+API Definition
+---------------
+

--- a/docs/source/candig_federation.rst
+++ b/docs/source/candig_federation.rst
@@ -1,8 +1,8 @@
 candig\_federation package
 ==========================
 
-Subpackages
------------
+The ``candig_federation`` package contains all the working code of the Federation service. This is split
+between an ``api`` package and a ``__main__.py`` driver module to run the service.
 
 .. toctree::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Welcome to CanDIG Federation's documentation!
 =============================================
 
 
-The ``candig_federation`` service is a one of the services which make up the CanDIG v2 platform. It acts as an entry
+The Federation service is a one of the services which make up the CanDIG v2 platform. It acts as an entry
 point for all incoming requests made to CanDIG, passing it along to the specified service, federating the request among the
 nodes in the CanDIG network and aggregating all the responses.
 

--- a/tests/test_uniform_federation.py
+++ b/tests/test_uniform_federation.py
@@ -890,7 +890,7 @@ def test_one_TimeOut_federated_local_TimeOut_two_peer_get(mock_requests, mock_se
             RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v3"]]
-            
+
 
 
 # Test Federation with two nodes (One timeout) and local valid -----------------------------------------------------

--- a/tests/test_uniform_federation.py
+++ b/tests/test_uniform_federation.py
@@ -509,9 +509,12 @@ def test_valid_federated_query_one_peer_get(mock_requests, mock_session, client)
     APP.app.config["peers"] = TWO
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
 
             assert RO["status"] == 200
             assert RO["results"] == [AP["v1"], AP["v2"]]
@@ -543,7 +546,8 @@ def test_valid_federated_query_one_peer_post(mock_requests, mock_session, client
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -560,7 +564,8 @@ def test_valid_federated_local_ConnErr_one_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -575,7 +580,8 @@ def test_valid_federated_local_TimeOut_one_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -589,9 +595,12 @@ def test_valid_federated_local_TimeOut_one_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = TWO
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v2"]]
 
@@ -602,9 +611,12 @@ def test_valid_federated_local_ConnErr_one_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = TWO
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path"   : TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type"    : "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v2"]]
 
@@ -618,7 +630,8 @@ def test_ConnErr_federated_valid_local_one_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -633,7 +646,8 @@ def test_TimeOut_federated_valid_local_one_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -647,9 +661,12 @@ def test_ConnErr_federated_valid_local_one_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = TWO
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v1"]]
 
@@ -660,9 +677,12 @@ def test_TimeOut_federated_valid_local_one_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = TWO
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v1"]]
 
@@ -694,9 +714,12 @@ def test_valid_federated_query_two_peer_get(mock_requests, mock_session, client)
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
 
             assert RO["status"] == 200
             assert RO["results"] == [AP["v1"], AP["v2"], AP["v3"]]
@@ -728,7 +751,8 @@ def test_valid_federated_query_two_peer_post(mock_requests, mock_session, client
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -745,7 +769,8 @@ def test_valid_federated_local_ConnErr_two_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -760,7 +785,8 @@ def test_valid_federated_local_TimeOut_two_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -774,9 +800,12 @@ def test_valid_federated_local_ConnErr_two_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v2"], AP["v3"]]
 
@@ -787,9 +816,12 @@ def test_valid_federated_local_TimeOut_two_peer_get(mock_requests, mock_session,
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v2"], AP["v3"]]
 
@@ -803,7 +835,8 @@ def test_one_TimeOut_federated_local_ConnErr_two_peer_post(mock_session,  client
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -818,7 +851,8 @@ def test_one_TimeOut_federated_local_TimeOut_two_peer_post(mock_session,  client
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -832,9 +866,12 @@ def test_one_TimeOut_federated_local_ConnErr_two_peer_get(mock_requests, mock_se
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v3"]]
 
@@ -845,11 +882,15 @@ def test_one_TimeOut_federated_local_TimeOut_two_peer_get(mock_requests, mock_se
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v3"]]
+            
 
 
 # Test Federation with two nodes (One timeout) and local valid -----------------------------------------------------
@@ -861,7 +902,8 @@ def test_one_TimeOut_federated_valid_two_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -876,7 +918,8 @@ def test_one_TimeOut_federated_local_valid_two_peer_post(mock_session,  client):
     with client:
         with APP.app.test_request_context(
                 data=json.dumps({"endpoint_path": TP["path"],
-                                 "endpoint_payload": ""}),
+                                 "endpoint_payload": "",
+                                 "request_type": "POST"}),
                 headers=Headers(fedHeader.headers)
         ):
             RO = operations.post_search()[0]
@@ -890,9 +933,12 @@ def test_one_TimeOut_federated_local_valid_two_peer_get(mock_requests, mock_sess
     APP.app.config["peers"] = THREE
     with client:
         with APP.app.test_request_context(
-                data={}, headers=Headers(fedHeader.headers)
+                data=json.dumps({"endpoint_path": TP["path"],
+                                 "endpoint_payload": "",
+                                 "request_type": "GET"}),
+                headers=Headers(fedHeader.headers)
         ):
-            RO = operations.get_search(TP["path"], "")[0]
+            RO = operations.post_search()[0]
             assert RO["status"] == 200
             assert RO["results"] == [AP["v1"], AP["v3"]]
 


### PR DESCRIPTION
While writing up the documentation for Federation and logging, I noticed that GET parameters were not accurately being passed into Federation due to a combination of Tyk parsing and the nested structure of request object. After a bit of testing, there wasn't a satisfactory way to make it work both with Federation independently and with Tyk in the middle. As a result, the OpenAPI Spec has now been changed to only use POST requests for Federation, but the an additional parameter has been added to specify the type of request to pass onto a microservice. 

![image(1)](https://user-images.githubusercontent.com/22246234/74578017-1c0b5b00-4f47-11ea-8d9c-1a9ea37a5cc2.png)
