### PR TITLE
Add check against beginning backslash in endpoint_path

### DIFF
--- a/candig_federation/api/operations.py
+++ b/candig_federation/api/operations.py
@@ -39,6 +39,14 @@ def post_search():
         data = json.loads(flask.request.data)
         request_type = data["request_type"]
         endpoint_path = data["endpoint_path"]
+        if endpoint_path[0] == "/":
+            return {
+                    "response": ("Invalid endpoint_path: {}. "
+                    "Please remove the / at the beginning: ".format(endpoint_path)),
+                    "status": 400,
+                    "service": "ErrorHandling"
+                    }, 400
+
         endpoint_payload = data["endpoint_payload"]
         endpoint_service = data["endpoint_service"]
         microservice_URL = APP.config['services'][endpoint_service]
@@ -59,7 +67,7 @@ def post_search():
         """
     return {
            "response": ("Invalid service name: {}. "
-           "Please make sure that the beginning of your endpoint_path matches a registered service: "
+           "Please make sure that the service requested matches a registered service: "
            "{} "
            .format(endpoint_service, list(APP.config['services'].keys()))),
            "status": 404,

--- a/tests/test_uniform_federation.py
+++ b/tests/test_uniform_federation.py
@@ -898,3 +898,18 @@ def test_one_TimeOut_federated_local_valid_two_peer_get(mock_requests, mock_sess
             assert RO["results"] == [AP["v1"], AP["v3"]]
 
 
+@patch('candig_federation.api.federation.requests.Session.get', side_effect=mocked_service_get)
+@patch('candig_federation.api.federation.FuturesSession.post', side_effect=mocked_async_requests_get)
+def test_invalid_backslash_endpoint_start(mock_requests, mock_session, client):
+    APP.app.config["peers"] = TWO
+    with client:
+        with APP.app.test_request_context(
+                data=json.dumps({"endpoint_path": "/fail/this/path",
+                                 "endpoint_payload": "",
+                                 "request_type": "GET",
+                                 "endpoint_service": TP["service"]
+                }),
+                headers=Headers(fedHeader.headers)
+        ):
+            RO = operations.post_search()[0]
+            assert RO["status"] == 400


### PR DESCRIPTION
Small PR which adds a validation check against an endpoint_path starting with "/". This backslash is added by the Federation service when constructing internal requests to fan out.