### PR TITLE
Add locations to response messages 

### DIFF
--- a/tests/test_local_federation.py
+++ b/tests/test_local_federation.py
@@ -45,8 +45,6 @@ def test_servers(server, ports):
     with open("./configs/servers.json") as j:
         j = json.load(j)
         servers = j["servers"]
-    print('r1:', r1.json())
-    print('j:', j["servers"])
 
     assert r1.json() == r2.json() == servers, \
         "The returned server URLs don't match servers.json"


### PR DESCRIPTION
- Both unsuccessful and successful responses return their respective location in the `message` field.
- API response structure unchanged