### PR TITLE
DIG-1240: API middleware service to handle queries across federated instances

### DIFF
--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -259,6 +259,7 @@ components:
           enum:
             - katsu
             - htsget
+            - query
         url:
           type: string
           description: local URL for use by the federation service


### PR DESCRIPTION
# Ticket
[DIG-1240](https://candig.atlassian.net/browse/DIG-1240)

# Description
This ticket adds query to the list of allowed services for federation.

# Linked tickets
- [CanDIGv2 main repo](https://github.com/CanDIG/CanDIGv2/pull/291)
- [Data portal](https://github.com/CanDIG/candig-data-portal/pull/96)
- [Query microservice](https://github.com/CanDIG/query/pull/1)

# To test
- That fanout calls through federation are able to access the query microservice.

[DIG-1240]: https://candig.atlassian.net/browse/DIG-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ