### PR TITLE
DIG-1377: Be consistent in our use of candig user inside containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
   pcre-dev \
   git
 
-RUN addgroup candig
+RUN addgroup -S candig && adduser -S candig -G candig
 
 COPY requirements.txt /app/federation/requirements.txt
 
@@ -41,6 +41,12 @@ COPY . /app/federation
 
 WORKDIR /app/federation
 
+RUN chown -R candig:candig /app/federation
+
 RUN mkdir /app/config
+
+RUN chown -R candig:candig /app/config
+
+USER candig
 
 ENTRYPOINT ["bash", "entrypoint.sh"]


### PR DESCRIPTION
## Tickets
[DIG-1377](https://candig.atlassian.net/browse/DIG-1377)

## Description

Adds the CanDIG user and group during the Dockerfile initialization, and makes sure that the stack is being run as the CanDIG user. This should ideally not change anything, and is only another layer of security (the root user in Docker is actually the same root as on your local filesystem? And we're just relying on Docker isolating the child process enough to prevent it from affecting things outside the container.) This is one PR out of six doing more-or-less the same thing.

[DIG-1377]: https://candig.atlassian.net/browse/DIG-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ