### PR TITLE
DIG-1149: Update for Alpine-3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN apk add --no-cache \
   curl \
   curl-dev \
   yaml-dev \
-  libressl-dev \
   pcre-dev \
   git
 


### PR DESCRIPTION
The only error I got when moving to Alpine 3.18 was a conflict on libressl-dev and the built-in openssl-dev? https://gitlab.alpinelinux.org/alpine/aports/-/issues/15182

Anyway, I tried to track down if we had any reason for explicitly installing libressl-dev, and I can't find any...I think maybe it was just always there? 

All tests seem to work without it.