### PR TITLE
DIG-1144: Update Python to 3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 dist: focal   # required for Python >= 3.7
 python:
-  - "3.9"
-  - "3.10"
+  - "3.12"
 
 install:
   - pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN apk add --no-cache \
   curl \
   curl-dev \
   yaml-dev \
-  libressl-dev \
   pcre-dev \
   git
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pytest==7.2.0
 pytest-cov==2.7.1
 requests-futures==1.0.0
 swagger-ui-bundle==0.0.5
-uwsgi==2.0.22
+uwsgi==2.0.23
 prometheus-flask-exporter==0.13.0
 Flask-Cors==3.0.10


### PR DESCRIPTION
This PR updates travis and uwsgi version for compatibility; it also picks up the removal of libressl-dev for Alpine 3.18; probably best to test and merge this after https://github.com/CanDIG/federation_service/pull/45.