### PR TITLE
Set the default timeout for Federation requests to 60s

### DIFF
--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -38,7 +38,7 @@ class FederationResponse:
     # pylint: disable=too-many-arguments
 
     def __init__(self, request, endpoint_path, endpoint_payload, request_dict, endpoint_service, return_mimetype='application/json',
-                 timeout=5):
+                 timeout=60):
         """Constructor method
         """
         self.results = {}


### PR DESCRIPTION
This is a temporary measure while we roll out performance enhancements.