### PR TITLE
DIG-1664: Do not log service-info (prevent health check flooding)

### DIFF
--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -13,7 +13,6 @@ from network import get_registered_servers, get_registered_services, register_se
 app = Flask(__name__)
 
 
-@apilog
 def service_info():
     """
     :return: Our own server.

--- a/federation.ini
+++ b/federation.ini
@@ -12,3 +12,5 @@ chmod-socket = 660
 vacuum = true
 
 die-on-term = true
+
+route = /service-info donotlog:


### PR DESCRIPTION
Suppress logging for the /service-info endpoint, to prevent the logs from getting flooded.

To test: Check that the logs are no longer filled every half minute.