### PR TITLE
Don't pass in OPA_SECRET anymore

### DIFF
--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -6,7 +6,6 @@ import os
 app = Flask(__name__)
 TEST_KEY = os.getenv("TEST_KEY")
 CANDIG_OPA_URL = os.getenv("CANDIG_OPA_URL")
-CANDIG_OPA_SECRET = os.getenv("CANDIG_OPA_SECRET")
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 
 
@@ -27,7 +26,7 @@ def is_site_admin(request):
         return True # no auth
     if "Authorization" in request.headers:
         try:
-            return authx.auth.is_site_admin(request, opa_url=CANDIG_OPA_URL, admin_secret=CANDIG_OPA_SECRET)
+            return authx.auth.is_site_admin(request, opa_url=CANDIG_OPA_URL)
         except Exception as e:
             print(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             app.logger.warning(f"Couldn't authorize site_admin: {type(e)} {str(e)}")

--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -5,7 +5,6 @@ import os
 
 app = Flask(__name__)
 TEST_KEY = os.getenv("TEST_KEY")
-CANDIG_OPA_URL = os.getenv("CANDIG_OPA_URL")
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 
 
@@ -26,7 +25,7 @@ def is_site_admin(request):
         return True # no auth
     if "Authorization" in request.headers:
         try:
-            return authx.auth.is_site_admin(request, opa_url=CANDIG_OPA_URL)
+            return authx.auth.is_site_admin(request)
         except Exception as e:
             print(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             app.logger.warning(f"Couldn't authorize site_admin: {type(e)} {str(e)}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,6 @@
 
 set -Euo pipefail
 
-export OPA_SECRET=$(cat /run/secrets/opa-service-token)
 export TYK_SECRET_KEY=$(cat /run/secrets/tyk-secret-key)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs~=23.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.3.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.2
 connexion==2.14.1
 decorator==4.4.0
 flask==2.2.5


### PR DESCRIPTION
Latest Opa and authx don't require the OPA_SECRET anymore. OPA_URL will be pulled out directly from the docker compose file's env var OPA_URL and doesn't need to be specified.