### PR TITLE
DIG-979: Move federation config to Vault service store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ dist: focal   # required for Python >= 3.7
 python:
   - "3.12"
 
+before_install:
+  - sudo mkdir -p /run/secrets
+  - sudo touch /run/secrets/vault-approle-token
+  - sudo chmod 777 /run/secrets/vault-approle-token
+  - echo "test" > /run/secrets/vault-approle-token
+  - sudo mkdir -p /home/candig
+  - sudo touch /home/candig/roleid
+  - sudo chmod 777 /home/candig/roleid
+  - echo "test" > /home/candig/roleid
+
 install:
   - pip install -r requirements.txt
 
@@ -11,4 +21,4 @@ script:
   - pytest --cov=candig_federation tests/ -vv
 
 env:
-  - CONFIG_DIR=config TRAVIS=true # Used to skip local integration tests in test_local_federation.py
+  - SERVICE_NAME=federation VAULT_URL=http://localhost CONFIG_DIR=config TRAVIS=true # Used to skip local integration tests in test_local_federation.py

--- a/candig_federation/apilog.py
+++ b/candig_federation/apilog.py
@@ -57,5 +57,8 @@ def apilog(func, *args, **kwargs):
 
     logentry = json.dumps(entrydict)
 
-    current_app.logger.info(logentry)
+    try:
+        current_app.logger.info(logentry)
+    except:
+        pass
     return func(*args, **kwargs)

--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -5,7 +5,6 @@ import os
 
 app = Flask(__name__)
 TEST_KEY = os.getenv("TEST_KEY")
-TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 
 
 def is_testing(request):
@@ -31,19 +30,3 @@ def is_site_admin(request):
             app.logger.warning(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             return False
     return False
-
-
-def add_provider_to_tyk(token, issuer):
-    return authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
-
-
-def remove_provider_to_tyk(issuer):
-    return authx.auth.remove_provider_to_tyk_api(TYK_FEDERATION_API_ID, issuer)
-
-
-def add_provider_to_opa(token, issuer):
-    return authx.auth.add_provider_to_opa(token, issuer)
-
-
-def remove_provider_to_opa(issuer):
-    return authx.auth.remove_provider_to_opa(issuer)

--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -270,14 +270,14 @@ class FederationResponse:
             try:
                 # self.announce_fed_out(request_type, url, endpoint_path, endpoint_payload)
                 response = {}
-                url = f"{server['url']}/v1/fanout"
+                url = f"{server['server']['url']}/v1/fanout"
                 response["response"] = async_session.post(url, json=args, headers=header, timeout=self.timeout)
-                response["location"] = server["location"]
+                response["location"] = server['server']["location"]
 
-                responses[server['id']] = response
+                responses[server['server']['id']] = response
 
             except Exception as e:
-                responses[server['id']] = f"async_requests {server['id']}: {type(e)} {str(e)}"
+                responses[server['server']['id']] = f"async_requests {server['server']['id']}: {type(e)} {str(e)}"
 
         return responses
 
@@ -373,7 +373,7 @@ class FederationResponse:
             # add locations:
             response['location'] = {}
             for server in self.servers:
-                response['location'][server] = self.servers[server]['location']
+                response['location'][server] = self.servers[server]['server']['location']
 
             # now deconvolute the result to an array:
             response_array = []

--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -28,10 +28,13 @@ paths:
     post:
       description: Add a server to the federation.
       operationId: operations.add_server
+      parameters:
+        - $ref: '#/components/parameters/register'
       requestBody:
         content:
           'application/json':
             schema:
+              nullable: true
               type: object
               required:
                 - server
@@ -107,6 +110,8 @@ paths:
         '500':
           description: Internal Error
     post:
+      parameters:
+        - $ref: '#/components/parameters/register'
       description: Add a service to the federation.
       operationId: operations.add_service
       requestBody:
@@ -194,6 +199,13 @@ components:
       schema:
         type: boolean
         default: true
+    register:
+      name: register
+      in: query
+      description: re-register all known servers/services
+      required: false
+      schema:
+          type: boolean
   schemas:
     FederatedRequestBody:
       type: object

--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -118,6 +118,7 @@ paths:
         content:
           'application/json':
             schema:
+              nullable: true
               $ref: "#/components/schemas/Service"
       responses:
         '201':

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -4,8 +4,10 @@ Methods to handle services and peer servers
 
 import json
 from flask import current_app
-import authz
 import authx.auth
+import os
+
+TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 
 
 def get_registered_servers():
@@ -40,11 +42,11 @@ def register_server(obj):
             token = obj['authentication']['token']
             issuer = obj['authentication']['issuer']
 
-            authz.add_provider_to_tyk(token, issuer)
+            authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
         except Exception as e:
             raise Exception(f"Failed to register server with tyk: {type(e)} {str(e)}")
         try:
-            authz.add_provider_to_opa(token, issuer)
+            authx.auth.add_provider_to_opa(token, issuer)
         except Exception as e:
             raise Exception(f"Failed to register server with opa: {type(e)} {str(e)}")
 

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -33,7 +33,7 @@ def register_server(obj):
                 found = True
         if found:
             return None
-        servers[new_server['id']] = new_server
+        servers[new_server['id']] = obj
 
     if 'testing' in obj['authentication']:
         new_server['testing'] = True

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -128,13 +128,19 @@ def add_service(register=False):
     """
     if not is_site_admin(request):
         return {"message": "User is not authorized to POST"}, 403
-    # if register=True, list known services in Vault and register them all
-    if register:
-        existing_services = get_registered_services()
-        for service in existing_services:
-            register_service(existing_services[service])
-    new_service = connexion.request.json
-    register_service(new_service)
+    try:
+        # if register=True, list known services in Vault and register them all
+        if register:
+            existing_services = get_registered_services()
+            for service in existing_services:
+                register_service(existing_services[service])
+        new_service = connexion.request.json
+        register_service(new_service)
+    except UnsupportedMediaType as e:
+        # this is the exception that gets thrown if the requestbody is null
+        return get_registered_services(), 200
+    except Exception as e:
+        return {"message": f"Couldn't add service: {type(e)} {str(e)} {connexion.request}"}, 500
     return get_registered_services()[new_service['id']], 200
 
 

--- a/candig_federation/server.py
+++ b/candig_federation/server.py
@@ -30,16 +30,6 @@ def main():
     APP.app.logger.addHandler(log_handler)
     APP.app.logger.setLevel(numeric_loglevel)
 
-    APP.app.config["service_file"] = os.path.abspath(f"{CONFIG_DIR}/services.json")
-    if not os.path.exists(APP.app.config["service_file"]):
-        with open(APP.app.config["service_file"], "w") as f:
-            f.write("{}")
-
-    APP.app.config["server_file"] = os.path.abspath(f"{CONFIG_DIR}/servers.json")
-    if not os.path.exists(APP.app.config["server_file"]):
-        with open(APP.app.config["server_file"], "w") as f:
-            f.write("{}")
-
     return APP
 
 def configure_app():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs~=23.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.2
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.3
 connexion==2.14.1
 decorator==4.4.0
 flask==2.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ requests-futures==1.0.0
 swagger-ui-bundle==0.0.5
 uwsgi==2.0.23
 prometheus-flask-exporter==0.13.0
-Flask-Cors==3.0.10
+Flask-Cors==4.0.1
 requests-mock>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ swagger-ui-bundle==0.0.5
 uwsgi==2.0.23
 prometheus-flask-exporter==0.13.0
 Flask-Cors==3.0.10
+requests-mock>=1.11.0

--- a/tests/test_data/three_servers.json
+++ b/tests/test_data/three_servers.json
@@ -1,32 +1,38 @@
 {
     "loc1": {
-        "id": "loc1",
-        "url": "http://10.9.208.132:6000",
-        "testing": true,
-        "location": {
-            "name": "loc1",
-            "province": "ON",
-            "province-code": "ca-on"
+        "server": {
+            "id": "loc1",
+            "url": "http://10.9.208.132:6000",
+            "testing": true,
+            "location": {
+                "name": "loc1",
+                "province": "ON",
+                "province-code": "ca-on"
+            }
         }
     },
     "loc2": {
-        "id": "loc2",
-        "url": "http://10.9.208.132:8000",
-        "testing": true,
-        "location": {
-            "name": "loc2",
-            "province": "ON",
-            "province-code": "ca-on"
+        "server": {
+            "id": "loc2",
+            "url": "http://10.9.208.132:8000",
+            "testing": true,
+            "location": {
+                "name": "loc2",
+                "province": "ON",
+                "province-code": "ca-on"
+            }
         }
     },
     "loc3": {
-        "id": "loc3",
-        "url": "http://10.9.208.132:9000",
-        "testing": true,
-        "location": {
-            "name": "loc3",
-            "province": "ON",
-            "province-code": "ca-on"
+        "server": {
+            "id": "loc3",
+            "url": "http://10.9.208.132:9000",
+            "testing": true,
+            "location": {
+                "name": "loc3",
+                "province": "ON",
+                "province-code": "ca-on"
+            }
         }
     }
 }

--- a/tests/test_data/two_servers.json
+++ b/tests/test_data/two_servers.json
@@ -1,22 +1,26 @@
 {
     "loc1": {
-        "id": "loc1",
-        "url": "http://10.9.208.132:6000",
-        "testing": true,
-        "location": {
-            "name": "loc1",
-            "province": "ON",
-            "province-code": "ca-on"
+        "server": {
+            "id": "loc1",
+            "url": "http://10.9.208.132:6000",
+            "testing": true,
+            "location": {
+                "name": "loc1",
+                "province": "ON",
+                "province-code": "ca-on"
+            }
         }
     },
     "loc2": {
-        "id": "loc2",
-        "url": "http://10.9.208.132:8000",
-        "testing": true,
-        "location": {
-            "name": "loc2",
-            "province": "ON",
-            "province-code": "ca-on"
+        "server": {
+            "id": "loc2",
+            "url": "http://10.9.208.132:8000",
+            "testing": true,
+            "location": {
+                "name": "loc2",
+                "province": "ON",
+                "province-code": "ca-on"
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of keeping an internal configuration file in the container, the servers and services are now kept in Federation's vault service store. Tests should still pass.