### PR TITLE
Allow a greater number of worker threads, with a low default

### DIFF
--- a/federation.ini
+++ b/federation.ini
@@ -4,7 +4,8 @@ chdir = candig_federation
 http = 0.0.0.0:4232
 
 log-master = true
-processes = 3
+cheaper = 4
+processes = 1024
 
 gid = candig
 socket = %d/federation.sock


### PR DESCRIPTION
# Ticket
[DIG-1673](https://candig.atlassian.net/browse/DIG-1673)

# Description
Currently when federation receives more than 3 requests at once (higher than the current number of processes) it enters thread pool exhaustion and deadlocks. This bugfix allows a greater maximum without using up a bunch of threads all at once at the cost of taking a while to spin up new workers.

[DIG-1673]: https://candig.atlassian.net/browse/DIG-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ