### PR TITLE
Set safe checking to be ON by default, and turned off with the Unsafe flag

### DIFF
--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -42,7 +42,7 @@ class FederationResponse:
     # pylint: disable=too-many-arguments
 
     def __init__(self, request, endpoint_path, endpoint_payload, request_dict, endpoint_service, return_mimetype='application/json',
-                 timeout=60, safe=False):
+                 timeout=60, unsafe=False):
         """Constructor method
         """
         self.results = {}
@@ -56,7 +56,7 @@ class FederationResponse:
         self.request_dict = request_dict
         self.servers = get_registered_servers()
         self.services = get_registered_services()
-        self.safe = safe
+        self.unsafe = unsafe
 
         try:
             self.token = self.request_dict.headers['Authorization']
@@ -279,7 +279,7 @@ class FederationResponse:
                 response = {}
                 response["location"] = server['server']["location"]
 
-                if self.safe and not server['server']['id'] in get_live_servers():
+                if not (self.unsafe or server['server']['id'] in get_live_servers()):
                     # Do not ping servers that are not live according to the heartbeat service
                     response["response"] = f"Safe check abort: {server['server']['id']} is assumed to be down"
                 else:

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -205,7 +205,7 @@ def post_search():
             endpoint_payload=endpoint_payload,
             request_dict=request,
             endpoint_service=endpoint_service,
-            safe="safe" in data
+            unsafe="unsafe" in data
         )
 
         return federation_response.get_response_object()


### PR DESCRIPTION
# Description
After the last end of sprint demo, it was suggested to have safe mode be on by default, with a flag to turn it off if needed. This builds off of #63 .

# To test
# To test

1. Build with this branch 
2. Run integration tests.
3. Delete the entry in the container's `/app/federation/live_servers.txt`. 
4. Send a request like the following:
```
curl -v candig.docker.internal:5080/federation/v1/fanout
  -H "Content-Type: application/json"
  -H "Authorization: Bearer $TOKEN"
  -d '{ "method": "GET", "path": "service-info", "service": "query", "payload": {} }'
```
You should get a response like the following:
```
[
  {
    "location": {
      "name": "Local",
      "province": "ON",
      "province-code": "ca-on"
    },
    "message": "handle_server_request failed on internal-1, federation = false: Safe check abort: internal-1 is assumed to be down",
    "service": "query",
    "status": 500
  }
]
```
5. Send an unsafe request:
```
curl -v candig.docker.internal:5080/federation/v1/fanout \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{ "method": "GET", "path": "service-info", "service": "query", "payload": {}, "unsafe": "True" }'
```
You should get the following:
```
[
  {
    "location": {
      "name": "Local",
      "province": "ON",
      "province-code": "ca-on"
    },
    "results": {
      "description": "A query microservice for operating with HTSGet & Katsu",
      "id": "org.candig.query",
      "name": "CanDIG query service",
      "organization": {
        "name": "CanDIG",
        "url": "https://www.distributedgenomics.ca"
      },
      "type": {
        "artifact": "query",
        "group": "org.candig",
        "version": "v0.1.0"
      },
      "version": "0.1.0"
    },
    "service": "query",
    "status": 200
  }
]
```