### PR TITLE
hotfix: hardcode /federation into server urls

### DIFF
--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -278,7 +278,7 @@ class FederationResponse:
                     response["response"] = f"Safe check abort: {server['server']['id']} is assumed to be down"
                 else:
                     # self.announce_fed_out(request_type, url, endpoint_path, endpoint_payload)
-                    url = f"{server['server']['url']}/v1/fanout"
+                    url = f"{server['server']['url']}/federation/v1/fanout"
 
                     # spawn each request in a gevent
                     jobs[server['server']['id']] = gevent.spawn(requests.post, url, json=args, headers=header, timeout=self.timeout)

--- a/candig_federation/heartbeat.py
+++ b/candig_federation/heartbeat.py
@@ -13,7 +13,7 @@ def check_pulse():
     log = ""
     try:
         for server in servers.values():
-            url = f"{server['server']['url']}/v1/service-info"
+            url = f"{server['server']['url']}/hello"
             log += f"\ntesting {url}"
             service_info = requests.get(url, timeout=2)
             if service_info.ok:

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -13,7 +13,6 @@ logger = CanDIGLogger(__file__)
 
 
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
-TYK_LISTEN_PATH = os.getenv("TYK_LISTEN_PATH", "federation")
 APPROLE_TOKEN = None
 if os.getenv("TESTING", False):
     APPROLE_TOKEN = "test"
@@ -33,8 +32,8 @@ def get_registered_servers():
 def register_server(obj):
     servers = get_registered_servers()
     new_server = obj['server']
-    if not new_server['url'].endswith(TYK_LISTEN_PATH):
-        new_server['url'] = new_server['url'] + '/' + TYK_LISTEN_PATH
+    if not new_server['url'].endswith("/federation"):
+        new_server['url'] = new_server['url'] + "/federation"
 
     if servers is not None:
         # check to see if it's already here:

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -32,6 +32,8 @@ def get_registered_servers():
 def register_server(obj):
     servers = get_registered_servers()
     new_server = obj['server']
+    if new_server['url'].endswith("/federation"):
+       new_server['url'].replace("/federation", "")
 
     if servers is not None:
         # check to see if it's already here:

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -13,6 +13,7 @@ logger = CanDIGLogger(__file__)
 
 
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
+TYK_LISTEN_PATH = os.getenv("TYK_LISTEN_PATH", "federation")
 APPROLE_TOKEN = None
 if os.getenv("TESTING", False):
     APPROLE_TOKEN = "test"
@@ -32,6 +33,9 @@ def get_registered_servers():
 def register_server(obj):
     servers = get_registered_servers()
     new_server = obj['server']
+    if not new_server['url'].endswith(TYK_LISTEN_PATH):
+        new_server['url'] = new_server['url'] + '/' + TYK_LISTEN_PATH
+
     if servers is not None:
         # check to see if it's already here:
         found = False

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -32,8 +32,6 @@ def get_registered_servers():
 def register_server(obj):
     servers = get_registered_servers()
     new_server = obj['server']
-    if not new_server['url'].endswith("/federation"):
-        new_server['url'] = new_server['url'] + "/federation"
 
     if servers is not None:
         # check to see if it's already here:

--- a/tests/test_data/test_structs.py
+++ b/tests/test_data/test_structs.py
@@ -80,9 +80,9 @@ TestParams = {
     "PORT2": "8892",
     "Headers": exampleHeaders,
     "Federate": fedHeader,
-    "Tyk1": "10.9.208.132:6000/v1/fanout",
-    "Tyk2": "10.9.208.132:8000/v1/fanout",
-    "Tyk3": "10.9.208.132:9000/v1/fanout",
+    "Tyk1": "10.9.208.132:6000/federation/v1/fanout",
+    "Tyk2": "10.9.208.132:8000/federation/v1/fanout",
+    "Tyk3": "10.9.208.132:9000/federation/v1/fanout",
     "path": "rnaget/projects",
     "service": "rnaget",
 }


### PR DESCRIPTION
(requires changes to .env as well)

Assumes that the urls saved for federation do not have the suffix "/federation" and append it directly before sending fanout calls.