### PR TITLE
hotfix: better error handling if a server fails to register

### DIFF
--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -57,11 +57,18 @@ def add_server(register=False):
     try:
         # if register=True, list known servers in Vault and register them all
         if register:
+            errors = {}
             existing_servers = get_registered_servers()
             for server in existing_servers:
-                register_server(existing_servers[server])
+                try:
+                    register_server(existing_servers[server])
+                except Exception as e:
+                    logger.debug(f"failed to register {existing_servers[server]['server']['id']} {type(e)} {str(e)}", request)
+                    errors[existing_servers[server]['server']['id']] = f"{type(e)} {str(e)}"
+            if len(errors) > 0:
+                return errors, 500
     except Exception as e:
-        logger.debug(f"Couldn't register server", request)
+        logger.debug(f"Couldn't register servers: {type(e)} {str(e)}", request)
         return {"message": f"Couldn't register servers: {type(e)} {str(e)} {connexion.request}"}, 500
     try:
         if connexion.request.json is not None and 'server' in connexion.request.json:


### PR DESCRIPTION
 Be more specific about *which* existing server failed to register during setup. To test:

* `make recompose-federation` with this branch
* add a server to the federation (it doesn't have to work both ways, just has to be a reachable server, e.g. BCGSC-DEV)
* `docker exec -it candigv2_federation_1 python`
* change the value of the BCGSC-DEV token:
```
Python 3.12.7 (main, Oct 19 2024, 18:29:53) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import authx.auth
>>> import json
>>> servers, s = authx.auth.get_service_store_secret("federation", key="servers")
>>> servers['servers']['BCGSC-DEV']['authentication']['token'] = 'sdfssdfsdf'
>>> authx.auth.set_service_store_secret("federation", key="servers", value=json.dumps(servers))
```
* `make recompose-federation`

You should see an error message during setup:
```
Register existing servers
POST response: 500 {
  "BCGSC-DEV": "<class 'Exception'> Failed to register server with tyk: <class 'jwt.exceptions.DecodeError'> Not enough segments"
}
```
