### PR TITLE
Hotfix: catch a few NoneType exceptions

### DIFF
--- a/candig_federation/heartbeat.py
+++ b/candig_federation/heartbeat.py
@@ -7,6 +7,8 @@ import os
 
 def check_pulse():
     servers = get_registered_servers()
+    if servers is None:
+        return
     if len(servers) == 0:
         return
     # Determine which sites we have access to

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -115,7 +115,11 @@ def list_services():
     """
     :return: Dictionary of registered services.
     """
-    return list(get_registered_services().values()), 200
+    services = get_registered_services()
+    if services is not None:
+        return list(services.values()), 200
+    logger.debug(f"Couldn't list services", request)
+    return {"message": "Couldn't list services"}, 500
 
 
 @app.route('/services/<path:service_id>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs~=23.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.5.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0
 connexion==2.14.1
 decorator==4.4.0


### PR DESCRIPTION
While turning containers on and off, I noted that federation's heartbeat daemon gets very unhappy if Vault is sealed and keeps throwing exceptions for NoneTypes. These fixes should help.

Before this, you can see what I mean by stopping the vault container. Federation service will start respawning the heartbeat process over and over because servers is None. If you recompose federation at this point, you'll also see more exceptions thrown during initialization.

After pulling this fix and recomposing federation, you should see that it more gracefully handles the sealed vault in both cases.

To get everything working again, start vault again and restart vault-runner. That will unseal the vault. If you wait about a minute for opa-runner and vault-runner to refresh their tokens, you can recompose federation and everything should be as it was.