### PR TITLE
DIG-1951: Federation checks for CanDIG user authorization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG venv_python
+ARG venv_python=3.12
 FROM python:${venv_python}
 
 LABEL Maintainer="CanDIG Project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN chown -R candig:candig /app/federation
 RUN mkdir /app/config
 
 RUN chown -R candig:candig /app/config
+RUN touch /app/initial_setup
+RUN chmod 777 /app/initial_setup
 
 USER candig
 

--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -32,3 +32,16 @@ def is_site_admin(request):
             logger.error(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             return False
     return False
+
+
+def is_candig_authorized(request):
+    return authx.auth.is_user_candig_authorized(request)
+
+
+def is_local_token(request):
+    token = authx.auth.get_auth_token(request)
+    permissions, status_code = authx.auth.get_opa_permissions(bearer_token=token)
+    if status_code == 200:
+        if "is_local_token" in permissions:
+            return permissions["is_local_token"]
+    return False

--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -11,6 +11,10 @@ logger = CanDIGLogger(__file__)
 
 app = Flask(__name__)
 TEST_KEY = os.getenv("TEST_KEY", None)
+if TEST_KEY is not None:
+    SERVICE_TOKEN = authx.auth.create_service_token()
+else:
+    SERVICE_TOKEN = TEST_KEY
 
 def is_testing(request):
     if request.headers.get("Test_Key") == TEST_KEY:

--- a/candig_federation/authz.py
+++ b/candig_federation/authz.py
@@ -2,14 +2,15 @@ from flask import Flask
 import authx.auth
 import os
 from candigv2_logging.logging import CanDIGLogger
+import server
 
+SERVICE_TOKEN = server.SERVICE_TOKEN
 
 logger = CanDIGLogger(__file__)
 
 
 app = Flask(__name__)
-TEST_KEY = os.getenv("TEST_KEY")
-
+TEST_KEY = os.getenv("TEST_KEY", None)
 
 def is_testing(request):
     if request.headers.get("Test_Key") == TEST_KEY:

--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -69,7 +69,7 @@ class FederationResponse:
             'Content-Type': self.return_mimetype,
             'Accept': self.return_mimetype,
             'Federation': 'false',
-            'Authorization': self.token,
+            'Authorization': self.token
         }
 
         self.service_headers = {}

--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -113,23 +113,26 @@ class FederationResponse:
         else:
             return True
 
-    def get_service(self, service, endpoint_path, endpoint_payload):
+    def send_service_request(self, service, request, endpoint_path, endpoint_payload):
         """
-        Sends a GET request to service, adds response to self.status and self.results
+        Sends a request to service, adds response to self.status and self.results
 
         :param service: name of service sending the response
         :param endpoint_path: Specific API endpoint of CanDIG service to be queried, may contain query string if GET
         :type endpoint_path: str
         :param endpoint_payload: Query parameters needed by endpoint specified in endpoint_path
-        :type endpoint_payload: object, {param0=value0, paramN=valueN} for GET
+        :type endpoint_payload: object, {param0=value0, paramN=valueN} for GET, JSON struct dependent on service endpoint for POST
         """
         try:
             request_handle = requests.Session()
             full_path = "{}/{}".format(self.services[service]['url'], endpoint_path)
-            # self.announce_fed_out("GET", service, endpoint_path)
 
-            resp = request_handle.get(
-                full_path, headers=self.header, params=endpoint_payload, timeout=self.timeout)
+            if request.upper() == "GET":
+                resp = request_handle.get(
+                    full_path, headers=self.header, params=endpoint_payload, timeout=self.timeout)
+            elif request.upper() == "POST":
+                resp = request_handle.post(
+                    full_path, headers=self.header, json=endpoint_payload)
             self.status = resp.status_code
             self.results = resp.json()
         except requests.exceptions.ConnectionError:
@@ -146,37 +149,6 @@ class FederationResponse:
             logger.debug(self.message)
             return
 
-    def post_service(self, service, endpoint_path, endpoint_payload):
-        """
-        Sends a POST request to service, adds response to self.status and self.results
-
-        :param service: name of service sending the response
-        :param endpoint_path: Specific API endpoint of CanDIG service to be queried, may contain query string if GET
-        :type endpoint_path: str
-        :param endpoint_payload: Query parameters needed by endpoint specified in endpoint_path
-        :type endpoint_payload: object, JSON struct dependent on service endpoint for POST
-        """
-        try:
-            request_handle = requests.Session()
-            full_path = "{}/{}".format(self.services[service]['url'], endpoint_path)
-            # self.announce_fed_out("POST", service, endpoint_path, endpoint_payload)
-            resp = request_handle.post(
-                full_path, headers=self.header, json=endpoint_payload)
-            self.status = resp.status_code
-            self.results = resp.json()
-        except requests.exceptions.ConnectionError:
-            self.status = 404
-            self.message = 'Connection Error. Peer server may be down.'
-            return
-        except requests.exceptions.Timeout:
-            self.status = 504
-            self.message = 'Peer server timed out, it may be down.'
-            return
-        except Exception as e:
-            self.status = 500
-            self.message = f"post_service: {type(e)} {str(e)}"
-            logger.debug(self.message)
-            return
 
     async def handle_server_request(self, request, endpoint_path, endpoint_payload, endpoint_service, header):
         """
@@ -222,7 +194,7 @@ class FederationResponse:
                     self.message[future_response_id] = f"Unauthorized: {response}"
                 else:
                     self.status[future_response_id] = status_code
-                    self.message[future_response_id] = f"handle_server_request failed on {future_response_id}, federation = {self.header['Federation']}"
+                    self.message[future_response_id] = f"handle_server_request failed on {future_response_id}, federation = {self.header['Federation']}: {response}"
             except AttributeError:
                 if isinstance(future_response, requests.exceptions.ConnectionError):
                     self.status[future_response_id] = 404
@@ -368,9 +340,10 @@ class FederationResponse:
                                            header=self.header)
 
             else:
-                self.get_service(service=self.endpoint_service,
-                                 endpoint_path=self.endpoint_path,
-                                 endpoint_payload=self.endpoint_payload)
+                self.send_service_request(request="GET",
+                                          service=self.endpoint_service,
+                                          endpoint_path=self.endpoint_path,
+                                          endpoint_payload=self.endpoint_payload)
         else:
 
             if self.federate_check():
@@ -380,9 +353,10 @@ class FederationResponse:
                                            endpoint_service=self.endpoint_service,
                                            header=self.header)
             else:
-                self.post_service(service=self.endpoint_service,
-                                  endpoint_path=self.endpoint_path,
-                                  endpoint_payload=self.endpoint_payload)
+                self.send_service_request(request="POST",
+                                          service=self.endpoint_service,
+                                          endpoint_path=self.endpoint_path,
+                                          endpoint_payload=self.endpoint_payload)
 
         response = {
             "status": self.status,

--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -11,6 +11,7 @@ import aiohttp
 from network import get_registered_servers, get_registered_services
 from heartbeat import get_live_servers
 from candigv2_logging.logging import CanDIGLogger
+from authz import SERVICE_TOKEN
 
 logger = CanDIGLogger(__file__)
 
@@ -74,6 +75,13 @@ class FederationResponse:
         self.service_headers = {}
         self.timeout = timeout
 
+    def insert_local_service_token(self):
+        if "X-Service-Token" in self.header and SERVICE_TOKEN not in self.header['X-Service-Token']:
+            self.header['X-Service-Token'] += "," + SERVICE_TOKEN
+        else:
+            self.header['X-Service-Token'] = SERVICE_TOKEN
+        logger.debug(f"X-Service-Token is {self.header['X-Service-Token']}")
+
     def announce_fed_out(self, request_type, destination, path):
         """
         Logging function to track requests being sent out by the Federation service
@@ -123,6 +131,9 @@ class FederationResponse:
         :param endpoint_payload: Query parameters needed by endpoint specified in endpoint_path
         :type endpoint_payload: object, {param0=value0, paramN=valueN} for GET, JSON struct dependent on service endpoint for POST
         """
+
+        self.insert_local_service_token()
+
         try:
             request_handle = requests.Session()
             full_path = "{}/{}".format(self.services[service]['url'], endpoint_path)
@@ -263,6 +274,9 @@ class FederationResponse:
             except Exception as e:
                 responses[server['server']['id']] = f"async_requests {server['server']['id']}: {type(e)} {str(e)}"
         async with aiohttp.ClientSession() as session:
+            if "X-Service-Token" not in header:
+                header['X-Service-Token'] = self.header
+
             tasks = [self.send_request(id, url, args, header, session) for (id, url) in jobs]
             results = await asyncio.gather(*tasks)
 

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -202,6 +202,21 @@ async def post_search():
     Response - List of service specific responses
     ServiceName - Name of service (used for logstash tagging)
     """
+
+    # If this call is the first time a user is calling fanout, we need to check for candig authz before passing it on. There shouldn't be any federation in the header.
+    # Internally, async_requests will call fanout again, but with federation = false and a service token. This service token will be passed on to the local service. A user won't be able to put in the service token.
+    # If a user calls fanout with federation = true, FederationResponse will call the service directly, but there won't be a service token, so the service will have to do its own authz check.
+
+    if "federation" in connexion.request.headers and connexion.request.headers['federation'] == "false" \
+    and "X-Service-Token" in connexion.request.headers and connexion.request.headers['X-Service-Token'] == SERVICE_TOKEN:
+        # federation = false in the headers means this is our self-generated call from async_requests. This is okay.
+        logger.debug(f"federation is false, {connexion.request.headers.keys()}")
+        pass
+    else:
+        # anything else has not been authzed yet.
+        if not is_candig_authorized(connexion.request):
+            return {"error": f"{connexion.request.client.host} User is not locally CanDIG authorized"}, 403
+
     try:
         logger.debug("Sending federated request", connexion.request)
         data = await connexion.request.json()

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -2,7 +2,7 @@
 Methods to handle incoming requests passed from Tyk
 """
 
-from authz import is_site_admin
+from authz import is_site_admin, is_candig_authorized, is_local_token
 import connexion
 from werkzeug.exceptions import UnsupportedMediaType
 from flask import Flask
@@ -226,7 +226,15 @@ async def post_search():
             unsafe="unsafe" in data
         )
 
+        federation_response.insert_local_service_token()
+
         resp, status = await federation_response.get_response_object()
+
+        if is_local_token(connexion.request):
+            logger.debug("local token, checking for authz")
+            if not is_candig_authorized(connexion.request):
+                return {"error": f"{connexion.request.client.host} User is not locally CanDIG authorized"}, 403
+
         return resp, status
 
     except Exception as e:

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -202,21 +202,6 @@ async def post_search():
     Response - List of service specific responses
     ServiceName - Name of service (used for logstash tagging)
     """
-
-    # If this call is the first time a user is calling fanout, we need to check for candig authz before passing it on. There shouldn't be any federation in the header.
-    # Internally, async_requests will call fanout again, but with federation = false and a service token. This service token will be passed on to the local service. A user won't be able to put in the service token.
-    # If a user calls fanout with federation = true, FederationResponse will call the service directly, but there won't be a service token, so the service will have to do its own authz check.
-
-    if "federation" in connexion.request.headers and connexion.request.headers['federation'] == "false" \
-    and "X-Service-Token" in connexion.request.headers and connexion.request.headers['X-Service-Token'] == SERVICE_TOKEN:
-        # federation = false in the headers means this is our self-generated call from async_requests. This is okay.
-        logger.debug(f"federation is false, {connexion.request.headers.keys()}")
-        pass
-    else:
-        # anything else has not been authzed yet.
-        if not is_candig_authorized(connexion.request):
-            return {"error": f"{connexion.request.client.host} User is not locally CanDIG authorized"}, 403
-
     try:
         logger.debug("Sending federated request", connexion.request)
         data = await connexion.request.json()

--- a/candig_federation/server.py
+++ b/candig_federation/server.py
@@ -2,14 +2,30 @@
 from flask_cors import CORS
 import connexion
 import candigv2_logging.logging
+import authx.auth
+import os
 
 candigv2_logging.logging.initialize()
+logger = candigv2_logging.logging.CanDIGLogger(__file__)
 
 # Create the application instance
 app = connexion.FlaskApp(__name__, specification_dir='./')
 CORS(app.app)
 
 app.add_api('federation.yaml', strict_validation=True, validate_responses=True)
+
+TEST_KEY = os.getenv("TEST_KEY", None)
+SERVICE_TOKEN = None
+if TEST_KEY is not None and SERVICE_TOKEN is None:
+    logger.debug("creating service token")
+    try:
+        with open("/home/candig/service_token.txt") as f:
+            SERVICE_TOKEN = f.read().strip()
+    except FileNotFoundError:
+        logger.debug("no token found")
+        pass
+else:
+    SERVICE_TOKEN = TEST_KEY
 
 def main():
     # Create the application instance

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,9 @@ export TYK_SECRET_KEY=$(cat /run/secrets/tyk-secret-key)
 
 
 
-if [[ -f "initial_setup" ]]; then
+if [[ -f "/app/initial_setup" ]]; then
+    python -c "from authx.auth import create_service_token
+print(create_service_token())" | tail -n 1 > /home/candig/service_token.txt
     rm initial_setup
 fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.11.8
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.3
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 connexion==3.1.0
 connexion[swagger-ui]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ requests-mock>=1.12.1
 gunicorn>=23.0.0
 uvicorn[standard]==0.30.6
 pyyaml>=4.2b1
-pytest==7.2.0
+pytest==8.3.3
 pytest-cov==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.11.8
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.0
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 connexion==3.1.0
 connexion[swagger-ui]
 connexion[flask]


### PR DESCRIPTION
Federation needs to check for candig authorization itself and only send the fanout call to other federation nodes if candig-authzed locally.
If a federation node gets a call from another server's fanout call, we know that it's from a candig-authzed user on that node, so federation can add its service token before sending the call to its locally-registered services.

I also consolidated the local get_service/post_service call into a single send_service_request call because it was basically the same code, slowly diverging. Also having FederationResponse.get_service and operations.get_service that do two different things is confusing.