### PR TITLE
DIG-2033: actually need to remove the provider from tyk

### DIFF
--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -70,6 +70,8 @@ def unregister_server(server_id):
     servers = get_registered_servers()
     result = None
     if servers is not None and server_id in servers:
+        issuer = servers[server_id]["authentication"]["issuer"]
+        authx.auth.remove_provider_from_tyk_api(TYK_FEDERATION_API_ID, issuer)
         result = servers.pop(server_id)
     stored_servers_dict, status_code = authx.auth.set_service_store_secret("federation", key="servers", value=json.dumps({"servers": servers}))
     if status_code != 200:

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -30,28 +30,29 @@ def get_registered_servers():
 
 
 def register_server(obj):
-    servers = get_registered_servers()
     new_server = obj['server']
+    token = obj['authentication']['token']
+    issuer = obj['authentication']['issuer']
+
     if new_server['url'].endswith("/federation"):
        new_server['url'].replace("/federation", "")
-
-    if servers is not None:
-        # check to see if it's already here:
-        found = False
-        for s in servers.values():
-            if json.dumps(s, sort_keys=True) == json.dumps(new_server, sort_keys=True):
-                found = True
-        if found:
-            return None
-        servers[new_server['id']] = obj
 
     if 'testing' in obj['authentication']:
         new_server['testing'] = True
     else:
         try:
-            token = obj['authentication']['token']
-            issuer = obj['authentication']['issuer']
-
+            jwt_data = authx.auth.decode_token(token, issuer)
+            client_id = jwt_data["azp"]
+            servers = get_registered_servers()
+            found = False
+            if servers is not None:
+                # check to see if this exact server is already here:
+                for s in servers.values():
+                    s_client_id = authx.auth.decode_token(s["authentication"]["token"], s["authentication"]["issuer"])["azp"]
+                    if s_client_id == client_id and s["authentication"]["issuer"] == issuer:
+                        if s["server"]["url"] != new_server["url"]:
+                            raise Exception(f"Cannot register another server with the same issuer and client")
+                        return None
             authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
         except Exception as e:
             raise Exception(f"Failed to register server with tyk: {type(e)} {str(e)}")
@@ -60,6 +61,7 @@ def register_server(obj):
         except Exception as e:
             raise Exception(f"Failed to register server with opa: {type(e)} {str(e)}")
 
+    servers[new_server['id']] = obj
     stored_servers_dict, status_code = authx.auth.set_service_store_secret("federation", key="servers", value=json.dumps({"servers": servers}))
     if status_code != 200:
         logger.error(f"Error in register_server: {stored_servers_dict}")

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -75,13 +75,14 @@ async def add_server(register=False):
         if req is not None and 'server' in req:
             new_server = req
             if register_server(new_server) is None:
-                return {"message": f"Server {new_server['server']['id']} already present"}, 204
+                return {"message": f"Server matching {new_server['server']['url']} already present"}, 200
             return get_registered_servers()[new_server['server']['id']]['server'], 201
+        return {"message": "Success"}, 200
     except UnsupportedMediaType as e:
         # this is the exception that gets thrown if the requestbody is null
         return get_registered_servers(), 200
     except Exception as e:
-        logger.debug(f"Couldn't add server", connexion.request)
+        logger.debug(f"Couldn't add server: {type(e)} {str(e)}", connexion.request)
         return {"message": f"Couldn't add server: {type(e)} {str(e)} {connexion.request}"}, 500
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.11.8
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.3
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/no-verify-jwt
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 connexion==3.1.0
 connexion[swagger-ui]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.11.8
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/no-verify-jwt
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.1
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 connexion==3.1.0
 connexion[swagger-ui]


### PR DESCRIPTION
Apparently I just forgot to call the remove_provider_from_tyk method when unregistering a server.

Test this by adding a server to your local federation, then checking the tyk federation policy: 
```
curl "http://candig.docker.internal:5080/tyk/apis/91" \
     -H 'x-tyk-authorization: <tmp/tyk/secret-key>'
```

There should be two providers. Then, delete the server you added. Doing the curl again should give you a policy with only one server.