### PR TITLE
DHDPS-401: external service registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ curl -X "POST" "http://candig.docker.internal:5080/federation/v1/servers" \
     }'
 ```
 
+### How to add external services
+In order for a service external to the CanDIG node to be registered as an external service, you must make sure that the tokens issued by the service's IDP contain the correct audience claim for the CanDIG node: you can find this audience in any CanDIG-issued token or in the CanDIG node's .env file, under KEYCLOAK_CLIENT_ID. Ask your OIDC administrator to do this, if needed.
+
+To register the service, use the /federation/v1/external-service POST endpoint, described in federation.yaml. This call must be authorized with a site administrator access token from your own server (obtainable via CanDIGv2/site_admin_token.py). The object should contain a valid JWT from the external service's identity issuer, possibly a service token or a special user designated as the "service user". The Keycloak endpoint URL of the issuer should also be included. This will be compared with the `iss` claim in the JWT to make sure that they are the same.
+
+```
+## add external service
+curl -X "POST" "http://candig.docker.internal:5080/federation/v1/external-service" \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <site admin token>' \
+     -d $'{
+  "service": "<external service name, unique in the system>",
+  "authentication": {
+    "token": "<service token>",
+    "issuer": "http://candig.docker.internal:8080/auth/realms/candig"
+  }
+}'
+```
+
 ## Running
 
 You should use `uwsgi` to run the app for all functionalities to work as expected. The `--master` flag enables graceful reloading of the server without closing the socket and is useful to apply  any changes to the code while developing. For more details, read the [uwsgi documentation](https://uwsgi-docs.readthedocs.io/en/latest/Management.html).

--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -42,7 +42,7 @@ class FederationResponse:
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
 
-    def __init__(self, request, endpoint_path, endpoint_payload, request_dict, endpoint_service, return_mimetype='application/json',
+    def __init__(self, request, endpoint_path, endpoint_payload, request_dict, endpoint_service, user_jwt, return_mimetype='application/json',
                  timeout=60, unsafe=False):
         """Constructor method
         """
@@ -59,11 +59,16 @@ class FederationResponse:
         self.services = get_registered_services()
         self.unsafe = unsafe
 
-        try:
-            self.token = self.request_dict.headers['Authorization']
-        except KeyError as e:
-            logger.warning("Request lacking Authorization header")
-            self.token = ""
+        if user_jwt is not None:
+            self.token = f"Bearer {user_jwt}"
+        else:
+            try:
+                self.token = self.request_dict.headers['Authorization']
+                token = self.token
+            except KeyError as e:
+                logger.warning("Request lacking Authorization header")
+                self.token = ""
+                token = self.token
 
         self.header = {
             'Content-Type': self.return_mimetype,

--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -98,6 +98,77 @@ paths:
           description: Server not found
         '500':
           description: Internal Error
+  /external-service:
+    get:
+      description: List external service.
+      operationId: operations.list_external_services
+      responses:
+        '200':
+          description: Successful query
+        '500':
+          description: Internal Error
+    post:
+      description: Add an external service.
+      operationId: operations.add_external_service
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              nullable: true
+              type: object
+              required:
+                - service
+                - authentication
+              properties:
+                service:
+                  type: string
+                  description: Name of the external service. Must be unique in the system.
+                authentication:
+                  type: object
+                  required:
+                    - token
+                    - issuer
+                  properties:
+                    issuer:
+                      type: string
+                      description: Issuer associated with the OIDC token.
+                    token:
+                      type: string
+                      description: OIDC id_token issued to the service user from the issuer.
+      responses:
+        '201':
+          description: Service registered successfully
+        '204':
+          description: Service already registered
+        '403':
+          description: Authorization Error
+        '500':
+          description: Internal Error
+  /external-service/{service_id}:
+    parameters:
+      - $ref: "#/components/parameters/service_id"
+    get:
+      description: Get an external service
+      operationId: operations.get_external_service
+      responses:
+        '200':
+          description: Successful query
+        '404':
+          description: Service not found
+        '500':
+          description: Internal Error
+    delete:
+      description: Unregister a service
+      operationId: operations.delete_external_service
+      responses:
+        '200':
+          description: Service unregistered successfully
+        '403':
+          description: Authorization Error
+        '404':
+          description: Service not found
+        '500':
+          description: Internal Error
   /services:
     get:
       description: List registered services.

--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -215,6 +215,9 @@ components:
         - payload
         - service
       properties:
+        user_jwt:
+          type: string
+          description: user jwt, if not the one in the Authorization header
         method:
           type: string
           description: method to be called on the endpoint

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -13,6 +13,7 @@ logger = CanDIGLogger(__file__)
 
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 TYK_HTSGET_API_ID = os.getenv("TYK_HTSGET_API_ID")
+TYK_INGEST_API_ID = os.getenv("TYK_INGEST_API_ID")
 CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY")
 APPROLE_TOKEN = None
 if os.getenv("TESTING", False):
@@ -115,6 +116,7 @@ def register_external_service(obj):
 
         # add provider to tyk: the method will check for and will not add duplicates.
         authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
+        authx.auth.add_provider_to_tyk_api(TYK_INGEST_API_ID, token, issuer)
 
         external_services = get_registered_external_services()
     except Exception as e:

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -3,7 +3,6 @@ Methods to handle services and peer servers
 """
 
 import json
-from flask import current_app
 import authx.auth
 import os
 from candigv2_logging.logging import CanDIGLogger
@@ -14,6 +13,7 @@ logger = CanDIGLogger(__file__)
 
 TYK_FEDERATION_API_ID = os.getenv("TYK_FEDERATION_API_ID")
 TYK_HTSGET_API_ID = os.getenv("TYK_HTSGET_API_ID")
+CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY")
 APPROLE_TOKEN = None
 if os.getenv("TESTING", False):
     APPROLE_TOKEN = "test"
@@ -83,6 +83,65 @@ def unregister_server(server_id):
     stored_servers_dict, status_code = authx.auth.set_service_store_secret("federation", key="servers", value=json.dumps({"servers": servers}))
     if status_code != 200:
         logger.error(f"Error in register_server: {stored_servers_dict}")
+    return result
+
+
+def get_registered_external_services():
+    stored_external_services_dict, status_code = authx.auth.get_service_store_secret("federation", key="external_services", token=APPROLE_TOKEN)
+    if status_code == 404:
+        # no value was found, so this must need to be initialized
+        stored_external_services_dict, status_code = authx.auth.set_service_store_secret("federation", key="external_services", value=json.dumps({"external_services": {}}), token=APPROLE_TOKEN)
+        return {}
+    if status_code != 200:
+        logger.error(f"Error in get_registered_external_services: {stored_external_services_dict}")
+        return None
+    return stored_external_services_dict["external_services"]
+
+
+def register_external_service(obj):
+    token = obj['authentication']['token']
+    issuer = obj['authentication']['issuer']
+
+    new_external_service = {
+        "service": obj["service"],
+        "issuer": issuer,
+        "token": token
+    }
+
+    try:
+        jwt_data = authx.auth.decode_token(token, issuer)
+        new_external_service["client_id"] = jwt_data["azp"]
+        new_external_service["user"] = jwt_data[CANDIG_USER_KEY]
+
+        # add provider to tyk: the method will check for and will not add duplicates.
+        authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
+
+        external_services = get_registered_external_services()
+    except Exception as e:
+        raise Exception(f"Failed to register external_service with tyk: {type(e)} {str(e)}")
+    try:
+        authx.auth.add_provider_to_opa(token, issuer)
+    except Exception as e:
+        raise Exception(f"Failed to register external_service with opa: {type(e)} {str(e)}")
+
+    external_services[new_external_service["service"]] = new_external_service
+    stored_external_services_dict, status_code = authx.auth.set_service_store_secret("federation", key="external_services", value=json.dumps({"external_services": external_services}))
+    if status_code != 200:
+        logger.error(f"Error in register_external_service: {stored_external_services_dict}")
+    return new_external_service
+
+
+def unregister_external_service(external_service_id):
+    external_services = get_registered_external_services()
+    result = None
+    if external_services is not None and external_service_id in external_services:
+        issuer = external_services[external_service_id]["issuer"]
+        # TODO: figure out how to remove this from the API if it's the only occurrence in both external_services AND federated servers
+        # authx.auth.remove_provider_from_tyk_api(TYK_FEDERATION_API_ID, issuer)
+        result = external_services.pop(external_service_id)
+    stored_external_services_dict, status_code = authx.auth.set_service_store_secret("federation", key="external_services", value=json.dumps({"external_services": external_services}))
+    if status_code != 200:
+        logger.error(f"Error in register_external_service: {stored_external_services_dict}")
     return result
 
 

--- a/candig_federation/network.py
+++ b/candig_federation/network.py
@@ -49,6 +49,7 @@ def register_server(obj):
             # add provider to tyk: the method will check for and will not add duplicates.
             authx.auth.add_provider_to_tyk_api(TYK_FEDERATION_API_ID, token, issuer)
             authx.auth.add_provider_to_tyk_api(TYK_HTSGET_API_ID, token, issuer)
+            authx.auth.add_provider_to_tyk_api(TYK_INGEST_API_ID, token, issuer)
 
             # check to see if this exact server is already here: if so, don't add it to our servers list
             servers = get_registered_servers()

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -3,15 +3,19 @@ Methods to handle incoming requests passed from Tyk
 """
 
 from authz import is_site_admin, is_candig_authorized, is_local_token
+from authx.auth import get_auth_token
 import connexion
 from werkzeug.exceptions import UnsupportedMediaType
 from flask import Flask
 from federation import FederationResponse
 from network import get_registered_servers, get_registered_services, get_registered_external_services, register_server, register_service, register_external_service, unregister_server, unregister_service, unregister_external_service
 from candigv2_logging.logging import CanDIGLogger
+import os
+import requests
 
 
 logger = CanDIGLogger(__file__)
+CANDIG_INGEST_PUBLIC_URL = os.getenv("CANDIG_INGEST_PUBLIC_URL")
 
 
 app = Flask(__name__)
@@ -134,9 +138,32 @@ async def add_external_service():
     try:
         req = await connexion.request.json()
         if req is not None and 'service' in req:
-            new_service = req
-            if register_external_service(new_service) is None:
+            new_service = register_external_service(req)
+            if new_service is None:
                 return {"message": f"Service matching {new_service['service']} already present"}, 200
+
+            # the new service user needs to be CanDIG-authorized:
+            headers = {
+                "Content-Type": "application/json; charset=utf-8"
+            }
+
+            # first, preapprove the service user:
+            headers["Authorization"] = f"Bearer {get_auth_token(connexion.request)}"
+            response = requests.post(
+                f"{CANDIG_INGEST_PUBLIC_URL}/user/preapproved/{new_service["user"]}",
+                headers=headers
+            )
+
+            # then, request authorization for the service user
+            headers["Authorization"] = f"Bearer {new_service['token']}"
+            response = requests.post(
+                f"{CANDIG_INGEST_PUBLIC_URL}/user/pending/request",
+                headers=headers
+            )
+
+            if response.status_code != 200:
+                return {"message": f"Service user {new_service["user"]} could not be authorized: {response.text}"}, response.status_code
+
             return get_registered_external_services()[new_service['service']], 201
         return {"message": "Success"}, 200
     except UnsupportedMediaType as e:

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -7,7 +7,7 @@ import connexion
 from werkzeug.exceptions import UnsupportedMediaType
 from flask import Flask
 from federation import FederationResponse
-from network import get_registered_servers, get_registered_services, register_server, register_service, unregister_server, unregister_service
+from network import get_registered_servers, get_registered_services, get_registered_external_services, register_server, register_service, register_external_service, unregister_server, unregister_service, unregister_external_service
 from candigv2_logging.logging import CanDIGLogger
 
 
@@ -110,6 +110,67 @@ def delete_server(server_id):
     if result is None:
         logger.debug(f"Server not found", connexion.request)
         return {"message": f"Server {server_id} not found"}, 404
+    return result, 200
+
+
+def list_external_services():
+    """
+    :return: Dictionary of registered external services.
+    """
+    services = get_registered_external_services()
+    if services is not None:
+        result = map(lambda x: x["service"], services.values())
+        return list(result), 200
+    logger.debug(f"Couldn't list services", connexion.request)
+    return {"message": "Couldn't list services"}, 500
+
+
+async def add_external_service():
+    """
+    :return: Service added.
+    """
+    if not is_site_admin(connexion.request):
+        return {"message": "User is not authorized to POST"}, 403
+    try:
+        req = await connexion.request.json()
+        if req is not None and 'service' in req:
+            new_service = req
+            if register_external_service(new_service) is None:
+                return {"message": f"Service matching {new_service['service']} already present"}, 200
+            return get_registered_external_services()[new_service['service']], 201
+        return {"message": "Success"}, 200
+    except UnsupportedMediaType as e:
+        # this is the exception that gets thrown if the requestbody is null
+        return get_registered_external_services(), 200
+    except Exception as e:
+        logger.debug(f"Couldn't add service: {type(e)} {str(e)}", connexion.request)
+        return {"message": f"Couldn't add service: {type(e)} {str(e)} {connexion.request}"}, 500
+
+
+@app.route('/external_services/<path:service_id>')
+def get_external_service(service_id):
+    """
+    :return: Service requested.
+    """
+    services = get_registered_external_services()
+    if services is not None and service_id in services:
+        return services[service_id], 200
+    else:
+        logger.debug(f"Couldn't find service {service_id}", connexion.request)
+        return {"message": f"Couldn't find service {service_id}"}, 404
+
+
+@app.route('/external_services/<path:service_id>')
+def delete_external_service(service_id):
+    """
+    :return: Service deleted.
+    """
+    if not is_site_admin(connexion.request):
+        return {"message": "User is not authorized to POST"}, 403
+    result = unregister_external_service(service_id)
+    if result is None:
+        logger.debug(f"Service not found", connexion.request)
+        return {"message": f"Service {service_id} not found"}, 404
     return result, 200
 
 

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -218,12 +218,17 @@ async def post_search():
 
         endpoint_payload = data["payload"]
         endpoint_service = data["service"]
+        user_jwt = None
+        if "user_jwt" in data:
+            user_jwt = data["user_jwt"]
+
         federation_response = FederationResponse(
             request=request_type,
             endpoint_path=endpoint_path,
             endpoint_payload=endpoint_payload,
             request_dict=connexion.request,
             endpoint_service=endpoint_service,
+            user_jwt=user_jwt,
             unsafe="unsafe" in data
         )
 

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -139,9 +139,6 @@ async def add_external_service():
         req = await connexion.request.json()
         if req is not None and 'service' in req:
             new_service = register_external_service(req)
-            if new_service is None:
-                return {"message": f"Service matching {new_service['service']} already present"}, 200
-
             # the new service user needs to be CanDIG-authorized:
             headers = {
                 "Content-Type": "application/json; charset=utf-8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.11.8
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.3
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 connexion==3.1.0
 connexion[swagger-ui]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask==3.1.1
 prometheus-flask-exporter==0.13.0
 Flask-Cors==6.0.0
 requests-mock>=1.12.1
+requests==2.32.4
 gunicorn>=23.0.0
 uvicorn[standard]==0.30.6
 pyyaml>=4.2b1


### PR DESCRIPTION
Described in https://github.com/CanDIG/CanDIGv2/pull/1128.

I left in the user_jwt property in the api because we already told Bitnobi about it, but I don't think it's needed for the fanout call anymore.