### PR TITLE
Bump candig-logging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.11.8
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.4
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3
 connexion==3.1.0
 connexion[swagger-ui]
 connexion[flask]


### PR DESCRIPTION
Vulnerability found with Dependabot in candig-logging, so we've got to bump the version everywhere