### PR TITLE
Don't limit the services allowed

### DIFF
--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -342,10 +342,6 @@ components:
       properties:
         id:
           type: string
-          enum:
-            - katsu
-            - htsget
-            - query
         url:
           type: string
           description: local URL for use by the federation service


### PR DESCRIPTION
Now that drs is a service that can be added into federation again (see [FEDERATION_SERVICES](https://github.com/CanDIG/CanDIGv2/blob/f5efd45267eadf94042a1b0445687cba35522a18/etc/env/example.env#L155)), it seems weird to limit the possible values of the services in the federation OpenAPI schema. I totally forgot that this was there when I added drs back, and I bet I will forget again if I add more values to FEDERATION_SERVICES later.

Before this change, even though the FEDERATION_SERVICES included drs, the output of get_services would never include drs. If you pull and recompose, you'll now see drs in the list of services that you get at the end of the recompose's output.