### PR TITLE
Add candig-api as a permissible service name

### DIFF
--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -272,6 +272,7 @@ components:
             - katsu
             - htsget
             - query
+            - candig-api
         url:
           type: string
           description: local URL for use by the federation service


### PR DESCRIPTION
This allows candig-api to be added as a service to federation. Will require upstream edits from https://github.com/CanDIG/CanDIGv3/pull/16