### PR TITLE
DIG-1838: allow specification of servers to exclude

### DIFF
--- a/candig_federation/federation.py
+++ b/candig_federation/federation.py
@@ -42,8 +42,9 @@ class FederationResponse:
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
 
-    def __init__(self, request, endpoint_path, endpoint_payload, request_dict, endpoint_service, user_jwt, return_mimetype='application/json',
-                 timeout=60, unsafe=False):
+    def __init__(self, request, endpoint_path, endpoint_payload, request_dict,
+        endpoint_service, user_jwt, return_mimetype='application/json',
+        timeout=60, unsafe=False, exclude_servers=None):
         """Constructor method
         """
         self.results = {}
@@ -58,6 +59,13 @@ class FederationResponse:
         self.servers = get_registered_servers()
         self.services = get_registered_services()
         self.unsafe = unsafe
+
+        if exclude_servers is not None and len(exclude_servers) > 0:
+            servers = {}
+            for server in self.servers:
+                if self.servers[server]["server"]["location"]["name"] not in exclude_servers:
+                    servers[server] = self.servers[server]
+            self.servers = servers
 
         if user_jwt is not None:
             self.token = f"Bearer {user_jwt}"

--- a/candig_federation/federation.yaml
+++ b/candig_federation/federation.yaml
@@ -342,10 +342,6 @@ components:
       properties:
         id:
           type: string
-          enum:
-            - katsu
-            - htsget
-            - query
         url:
           type: string
           description: local URL for use by the federation service

--- a/candig_federation/operations.py
+++ b/candig_federation/operations.py
@@ -302,6 +302,9 @@ async def post_search():
                     }, 400
 
         endpoint_payload = data["payload"]
+        exclude_servers = None
+        if "exclude_servers" in endpoint_payload:
+            exclude_servers = endpoint_payload.pop("exclude_servers").split('|')
         endpoint_service = data["service"]
         user_jwt = None
         if "user_jwt" in data:
@@ -314,7 +317,8 @@ async def post_search():
             request_dict=connexion.request,
             endpoint_service=endpoint_service,
             user_jwt=user_jwt,
-            unsafe="unsafe" in data
+            unsafe="unsafe" in data,
+            exclude_servers=exclude_servers
         )
 
         federation_response.insert_local_service_token()


### PR DESCRIPTION
If exclude_servers is specified as part of the post_search payload, remove them from the servers used in the fanout.